### PR TITLE
added support for building against the android SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,12 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tony19</groupId>
+            <artifactId>named-regexp</artifactId>
+            <version>0.2.3</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/retromock/MockClient.java
+++ b/src/main/java/retromock/MockClient.java
@@ -1,7 +1,15 @@
 package retromock;
 
-import org.hamcrest.*;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
 import org.hamcrest.core.AnyOf;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
 import retrofit.client.Client;
 import retrofit.client.Header;
 import retrofit.client.Request;
@@ -11,154 +19,175 @@ import retromock.matchers.IsRequestWithMethod;
 import retromock.matchers.IsRequestWithUrl;
 import retromock.parser.HttpParser;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-
 import static org.hamcrest.core.AllOf.allOf;
 import static retromock.matchers.IsHeader.header;
 import static retromock.matchers.IsRequestWithHeaders.withHeaders;
 
 public class MockClient implements Client {
-    
-    private final List<Route> routes;
 
-    private MockClient(List<Route> routes) {
-        this.routes = routes;
+  private final List<Route> routes;
+
+  private MockClient(List<Route> routes) {
+    this.routes = routes;
+  }
+
+  @Override
+  public Response execute(Request request) throws IOException {
+    List<Matcher<? super Request>> unmatchedRoutes = new LinkedList<>();
+    for (Route route : routes) {
+      if (route.requestMatcher.matches(request)) return route.response.createFrom(request);
+      unmatchedRoutes.add(route.requestMatcher);
+    }
+    StringDescription description = new StringDescription();
+    AnyOf.anyOf(unmatchedRoutes).describeTo(description);
+    return new Response(
+        request.getUrl(),
+        404,
+        "No route matched",
+        Collections.<Header>emptyList(),
+        new TypedString("No matching route found. expected:\n" + description.toString())
+    );
+  }
+
+  public static Provider when() {
+    return new Provider();
+  }
+
+  public static class Provider implements Client.Provider {
+
+    final List<Route> routes = new LinkedList<>();
+
+    public RouteBuilder aRequest() {
+      return new RouteBuilder();
     }
 
-    @Override
-    public Response execute(Request request) throws IOException {
-        List<Matcher<? super Request>> unmatchedRoutes = new LinkedList<>();
-        for (Route route : routes) {
-            if (route.requestMatcher.matches(request)) return route.response.createFrom(request);
-            unmatchedRoutes.add(route.requestMatcher);
-        }
-        StringDescription description = new StringDescription();
-        AnyOf.anyOf(unmatchedRoutes).describeTo(description);
-        return new Response(
-                request.getUrl(),
-                404,
-                "No route matched",
-                Collections.<Header>emptyList(), 
-                new TypedString("No matching route found. expected:\n" + description.toString())
-        );
+    public RouteBuilder GET() {
+      return aRequest().withMethod("GET");
     }
 
-    public static Provider when() { return new Provider(); }
-    
-    public static class Provider implements Client.Provider {
+    public RouteBuilder GET(final String path) {
+      return GET().withPath(path);
+    }
 
-        final List<Route> routes = new LinkedList<>();
+    public RouteBuilder POST() {
+      return aRequest().withMethod("POST");
+    }
 
-        public RouteBuilder aRequest() { return new RouteBuilder(); }
+    public RouteBuilder POST(final String path) {
+      return POST().withPath(path);
+    }
 
-        public RouteBuilder GET() { return aRequest().withMethod("GET"); }
-        public RouteBuilder GET(final String path) { return GET().withPath(path); }
+    public RouteBuilder PUT() {
+      return aRequest().withMethod("PUT");
+    }
 
-        public RouteBuilder POST() { return aRequest().withMethod("POST"); }
-        public RouteBuilder POST(final String path) { return POST().withPath(path); }
+    public RouteBuilder PUT(final String path) {
+      return PUT().withPath(path);
+    }
 
-        public RouteBuilder PUT() { return aRequest().withMethod("PUT"); }
-        public RouteBuilder PUT(final String path) { return PUT().withPath(path); }
+    public RouteBuilder DELETE() {
+      return aRequest().withMethod("DELETE");
+    }
 
-        public RouteBuilder DELETE() { return aRequest().withMethod("DELETE"); }
-        public RouteBuilder DELETE(final String path) { return DELETE().withPath(path); }
+    public RouteBuilder DELETE(final String path) {
+      return DELETE().withPath(path);
+    }
 
         /* syntax sugar */
 
-        public Provider and() { return this; }
-
-        public Provider when() { return this; }
-
-        @Override public MockClient get() {
-            return new MockClient(routes);
-        }
-
-        public class RouteBuilder {
-            final List<Matcher<? super Request>> matchers = new LinkedList<>();
-
-            public RouteBuilder matching(Matcher<? super Request> requestMatcher) {
-                matchers.add(requestMatcher);
-                return this;
-            }
-
-            public RouteBuilder withMethod(String method) {
-                return matching(IsRequestWithMethod.withMethod(method));
-            }
-
-            public RouteBuilder withHeader(String headerName, Matcher<String> headerValue) {
-                return matching(withHeaders(header(headerName, headerValue)));
-            }
-
-            public RouteBuilder withPath(String url) {
-                return matching(IsRequestWithUrl.withPath(url));
-            }
-
-            public Provider thenReturn(Response response) {
-                return thenReturn(ResponseFactory.always(response));
-            }
-
-            public Provider thenReturn(File file) {
-                return thenReturn(ResponseFactory.fromFile(file));
-            }
-
-            public Provider thenReturn(Path path) {
-                return thenReturn(ResponseFactory.fromFile(path));
-            }
-
-            public Provider thenReturn(ResponseFactory response) {
-                Matcher<Request> requestMatcher = allOf(matchers);
-                routes.add(Route.of(requestMatcher, response));
-                return Provider.this;
-            }
-        }
-
-    }
-    
-    private static class Route {
-        Matcher<Request> requestMatcher;
-        ResponseFactory response;
-        private static Route of(Matcher<Request> requestMatcher, ResponseFactory response) {
-            Route res = new Route();
-            res.requestMatcher = requestMatcher;
-            res.response = response;
-            return res;
-        }
+    public Provider and() {
+      return this;
     }
 
-    public static abstract class ResponseFactory {
-        public static ResponseFactory always(final Response response) {
-            return new ResponseFactory() {
-                @Override
-                public Response createFrom(Request request) {
-                    return response;
-                }
-            };
-        }
-
-        public static ResponseFactory fromFile(final File file) {
-            return new ResponseFactory() {
-                @Override
-                public Response createFrom(Request request) throws IOException {
-                    return HttpParser.parse(request.getUrl(), file);
-                }
-            };
-        }
-
-        public static ResponseFactory fromFile(final Path path) {
-            return new ResponseFactory() {
-                @Override
-                public Response createFrom(Request request) throws IOException {
-                    return HttpParser.parse(request.getUrl(), path);
-                }
-            };
-        }
-
-        public abstract Response createFrom(Request request) throws IOException;
+    public Provider when() {
+      return this;
     }
 
+    @Override
+    public MockClient get() {
+      return new MockClient(routes);
+    }
+
+    public class RouteBuilder {
+      final List<Matcher<? super Request>> matchers = new LinkedList<>();
+
+      public RouteBuilder matching(Matcher<? super Request> requestMatcher) {
+        matchers.add(requestMatcher);
+        return this;
+      }
+
+      public RouteBuilder withMethod(String method) {
+        return matching(IsRequestWithMethod.withMethod(method));
+      }
+
+      public RouteBuilder withHeader(String headerName, Matcher<String> headerValue) {
+        return matching(withHeaders(header(headerName, headerValue)));
+      }
+
+      public RouteBuilder withPath(String url) {
+        return matching(IsRequestWithUrl.withPath(url));
+      }
+
+      public Provider thenReturn(Response response) {
+        return thenReturn(ResponseFactory.always(response));
+      }
+
+      public Provider thenReturn(File file) {
+        return thenReturn(ResponseFactory.fromFile(file));
+      }
+
+      public Provider thenReturn(String path) {
+        return thenReturn(ResponseFactory.fromFile(path));
+      }
+
+      public Provider thenReturn(ResponseFactory response) {
+        Matcher<Request> requestMatcher = allOf(matchers);
+        routes.add(Route.of(requestMatcher, response));
+        return Provider.this;
+      }
+    }
+  }
+
+  private static class Route {
+    Matcher<Request> requestMatcher;
+    ResponseFactory response;
+
+    private static Route of(Matcher<Request> requestMatcher, ResponseFactory response) {
+      Route res = new Route();
+      res.requestMatcher = requestMatcher;
+      res.response = response;
+      return res;
+    }
+  }
+
+  public static abstract class ResponseFactory {
+    public static ResponseFactory always(final Response response) {
+      return new ResponseFactory() {
+        @Override
+        public Response createFrom(Request request) {
+          return response;
+        }
+      };
+    }
+
+    public static ResponseFactory fromFile(final File file) {
+      return new ResponseFactory() {
+        @Override
+        public Response createFrom(Request request) throws IOException {
+          return HttpParser.parse(request.getUrl(), file);
+        }
+      };
+    }
+
+    public static ResponseFactory fromFile(final String path) {
+      return new ResponseFactory() {
+        @Override
+        public Response createFrom(Request request) throws IOException {
+          return HttpParser.parse(request.getUrl(), new File(path));
+        }
+      };
+    }
+
+    public abstract Response createFrom(Request request) throws IOException;
+  }
 }

--- a/src/main/java/retromock/matchers/IsHeader.java
+++ b/src/main/java/retromock/matchers/IsHeader.java
@@ -1,12 +1,13 @@
 package retromock.matchers;
 
+import android.util.Base64;
+
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
-import retrofit.client.Header;
-
-import javax.xml.bind.DatatypeConverter;
 
 import java.nio.charset.Charset;
+
+import retrofit.client.Header;
 
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -14,42 +15,42 @@ import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 
 public class IsHeader {
 
-    private static final Charset UTF_8;
+  private static final Charset UTF_8;
 
-    static {
-        UTF_8 = Charset.forName("UTF-8");
+  static {
+    UTF_8 = Charset.forName("UTF-8");
+  }
+
+  public static Matcher<Header> header(String name, Matcher<String> value) {
+    return allOf(new HeaderName(equalToIgnoringCase(name)), new HeaderValue(value));
+  }
+
+  public static Matcher<Header> basicAuth(String username, String password) {
+    final String headerVal = Base64.encodeToString((username + ":" + password).getBytes(UTF_8), Base64.DEFAULT);
+    return header("Authorization", equalTo("Basic " + headerVal));
+  }
+
+  static class HeaderName extends FeatureMatcher<Header, String> {
+
+    public HeaderName(Matcher<? super String> subMatcher) {
+      super(subMatcher, "a header with name", "name");
     }
 
-    public static Matcher<Header> header(String name, Matcher<String> value) {
-        return allOf(new HeaderName(equalToIgnoringCase(name)), new HeaderValue(value));
+    @Override
+    protected String featureValueOf(Header header) {
+      return header.getName();
+    }
+  }
+
+  static class HeaderValue extends FeatureMatcher<Header, String> {
+
+    public HeaderValue(Matcher<? super String> subMatcher) {
+      super(subMatcher, "a header with value", "value");
     }
 
-    public static Matcher<Header> basicAuth(String username, String password) {
-        final String headerVal = DatatypeConverter.printBase64Binary((username + ":" + password).getBytes(UTF_8));
-        return header("Authorization", equalTo("Basic " + headerVal));
+    @Override
+    protected String featureValueOf(Header header) {
+      return header.getValue();
     }
-
-    static class HeaderName extends FeatureMatcher<Header, String> {
-
-        public HeaderName(Matcher<? super String> subMatcher) {
-            super(subMatcher, "a header with name", "name");
-        }
-
-        @Override
-        protected String featureValueOf(Header header) {
-            return header.getName();
-        }
-    }
-
-    static class HeaderValue extends FeatureMatcher<Header, String> {
-
-        public HeaderValue(Matcher<? super String> subMatcher) {
-            super(subMatcher, "a header with value", "value");
-        }
-
-        @Override
-        protected String featureValueOf(Header header) {
-            return header.getValue();
-        }
-    }
+  }
 }

--- a/src/main/java/retromock/parser/HttpParser.java
+++ b/src/main/java/retromock/parser/HttpParser.java
@@ -1,21 +1,33 @@
 package retromock.parser;
 
+import com.google.code.regexp.Matcher;
+import com.google.code.regexp.Pattern;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+
 import retrofit.client.Header;
 import retrofit.client.Response;
 import retrofit.mime.TypedByteArray;
 import retrofit.mime.TypedInput;
 
-import java.io.*;
-import java.nio.charset.Charset;
-import java.nio.file.Path;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.*;
-import java.util.regex.*;
 
 /**
  * Parses a {@linkplain java.io.Reader}, e.g. from a flat file, into a {@linkplain retrofit.client.Response} object.
- *
+ * <p/>
  * For example you could prepare a mocked {@linkplain retrofit.client.Response} in a plain text file like this:
  * <pre>
  * HTTP/1.1 200 OK
@@ -26,7 +38,7 @@ import java.util.regex.*;
  *
  * Hello World!
  * </pre>
- *
+ * <p/>
  * The placeholder {@code ${DATE}} will be replaced with the current date.
  * The placeholder {@code ${LENGTH}} will be replaced with the actual length of the body.
  * The {@code charset} parameter of {@code Content-Type} is considered while parsing the body.
@@ -35,210 +47,216 @@ import java.util.regex.*;
  */
 public class HttpParser {
 
-    private static final Pattern STATUS_LINE_PATTERN = Pattern.compile("HTTP/1\\.1 (?<statusCode>\\d{3}) (?<statusReason>.+)");
-    private static final Pattern HEADER_PATTERN = Pattern.compile("(?<name>[a-zA-Z-]+): (?<value>.+)");
-    private static final Pattern CHARSET_PATTERN = Pattern.compile("charset=(?<charset>.+\\b)");
-    private static final String DEFAULT_CONTENT_TYPE = "text/plain; charset=UTF-8";
+  private static final Pattern STATUS_LINE_PATTERN = Pattern.compile("HTTP/1\\.1 (?<statusCode>\\d{3}) (?<statusReason>.+)");
+  private static final Pattern HEADER_PATTERN = Pattern.compile("(?<name>[a-zA-Z-]+): (?<value>.+)");
+  private static final Pattern CHARSET_PATTERN = Pattern.compile("charset=(?<charset>.+\\b)");
+  private static final String DEFAULT_CONTENT_TYPE = "text/plain; charset=UTF-8";
 
-    /**
-     * Parses a {@linkplain java.io.BufferedReader} into a {@linkplain retrofit.client.Response} object.
-     *
-     * @param url URL this mock response is answering for
-     * @param input {@link java.io.BufferedReader} to read from
-     * @return {@link retrofit.client.Response} object filled with data from the {@linkplain java.io.BufferedReader}
-     * @throws IOException If an I/O error occurs while parsing
-     */
-    public static Response parse(String url, BufferedReader input) throws IOException {
-        Status status = status(input);
-        List<Header> headers = headers(input);
-        TypedInput body = body(contentType(headers), input);
-        headers = new PlaceholderReplacer(headers)
-                .withDate(new Date())
-                .withLength(body)
-                .build();
+  /**
+   * Parses a {@linkplain java.io.BufferedReader} into a {@linkplain retrofit.client.Response} object.
+   *
+   * @param url   URL this mock response is answering for
+   * @param input {@link java.io.BufferedReader} to read from
+   * @return {@link retrofit.client.Response} object filled with data from the {@linkplain java.io.BufferedReader}
+   * @throws IOException If an I/O error occurs while parsing
+   */
+  public static Response parse(String url, BufferedReader input) throws IOException {
+    Status status = status(input);
+    List<Header> headers = headers(input);
+    TypedInput body = body(contentType(headers), input);
+    headers = new PlaceholderReplacer(headers)
+        .withDate(new Date())
+        .withLength(body)
+        .build();
 
-        return new Response(
-                url,
-                status.code(),
-                status.reason(),
-                headers,
-                body
-        );
+    return new Response(
+        url,
+        status.code(),
+        status.reason(),
+        headers,
+        body
+    );
+  }
+
+  /**
+   * Parses a {@linkplain java.io.Reader} into a {@linkplain retrofit.client.Response} object.
+   *
+   * @param url   URL this mock response is answering for
+   * @param input {@link java.io.Reader} to read from
+   * @return {@link retrofit.client.Response} object filled with data from the {@linkplain java.io.Reader}
+   * @throws IOException If an I/O error occurs while parsing
+   */
+  public static Response parse(String url, Reader input) throws IOException {
+    try (BufferedReader reader = new BufferedReader(input)) {
+      return parse(url, reader);
+    }
+  }
+
+  /**
+   * Parses an {@linkplain java.io.InputStream} into a {@linkplain retrofit.client.Response} object.
+   *
+   * @param url URL this mock response is answering for
+   * @param is  {@link java.io.InputStream} to read from
+   * @return {@link retrofit.client.Response} object filled with data from the {@linkplain java.io.InputStream}
+   * @throws IOException If an I/O error occurs while parsing
+   */
+  public static Response parse(String url, InputStream is) throws IOException {
+    try (Reader reader = new InputStreamReader(is)) {
+      return parse(url, reader);
+    }
+  }
+
+  /**
+   * Parses a {@linkplain java.io.File} into a {@linkplain retrofit.client.Response} object.
+   *
+   * @param url  URL this mock response is answering for
+   * @param file {@link java.io.File} to read from
+   * @return {@link retrofit.client.Response} object filled with data from the {@linkplain java.io.File}
+   * @throws IOException If an I/O error occurs while parsing
+   */
+  public static Response parse(String url, File file) throws IOException {
+    try (Reader reader = new FileReader(file)) {
+      return parse(url, reader);
+    }
+  }
+
+  /**
+   * Parses a {@linkplain java.lang.String} into a {@linkplain retrofit.client.Response} object.
+   *
+   * @param url  URL this mock response is answering for
+   * @param path {@link java.lang.String} to read from
+   * @return {@link retrofit.client.Response} object filled with data from the {@linkplain java.lang.String}
+   * @throws IOException If an I/O error occurs while parsing
+   */
+  public static Response parse(String url, String path) throws IOException {
+    return parse(url, new File(path));
+  }
+
+  private interface Status {
+    int code();
+
+    String reason();
+  }
+
+  private static Status status(BufferedReader input) throws IOException {
+    String statusLine = input.readLine();
+    if (statusLine == null || statusLine.isEmpty()) {
+      throw invalidStatusLine();
+    }
+    final Matcher matcher = STATUS_LINE_PATTERN.matcher(statusLine);
+    if (matcher.find()) {
+      return new Status() {
+        public int code() {
+          return Integer.parseInt(matcher.group("statusCode"));
+        }
+
+        public String reason() {
+          return matcher.group("statusReason");
+        }
+      };
+    } else {
+      throw invalidStatusLine();
+    }
+  }
+
+  private static RuntimeException invalidStatusLine() {
+    throw new IllegalArgumentException("Input does not begin with a status line");
+  }
+
+  private static List<Header> headers(BufferedReader input) throws IOException {
+    List<Header> headers = new ArrayList<>();
+    String line;
+    while (isNotEmptyOrNull(line = input.readLine())) {
+      Matcher m = HEADER_PATTERN.matcher(line);
+      if (m.find()) {
+        headers.add(new Header(m.group("name"), m.group("value")));
+      }
+    }
+    return headers;
+  }
+
+  private static boolean isNotEmptyOrNull(final String line) {
+    return line != null && !line.isEmpty();
+  }
+
+  private static String contentType(List<Header> headers) {
+    String contentType = DEFAULT_CONTENT_TYPE;
+    for (Header header : headers) {
+      if ("Content-Type".equalsIgnoreCase(header.getName())) {
+        contentType = header.getValue();
+        break;
+      }
+    }
+    return contentType;
+  }
+
+  private static TypedInput body(String mimeType, BufferedReader input) throws IOException {
+    StringBuilder body = new StringBuilder();
+    String line;
+    while ((line = input.readLine()) != null) {
+      body.append(line).append('\n');
+    }
+    return new TypedByteArray(mimeType, body.toString().getBytes(charset(mimeType)));
+  }
+
+  private static Charset charset(String mimeType) {
+    Matcher m = CHARSET_PATTERN.matcher(mimeType);
+    if (m.find()) {
+      return Charset.forName(m.group("charset"));
+    } else {
+      return Charset.defaultCharset();
+    }
+  }
+
+  private static class PlaceholderReplacer {
+
+    static final TimeZone GMT = TimeZone.getTimeZone("GMT");
+    final DateFormat dateFormat;
+    final List<Header> headers;
+    String length;
+    String date;
+
+    PlaceholderReplacer(List<Header> headers) {
+      this.headers = headers;
+      this.dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
+      this.dateFormat.setTimeZone(GMT);
     }
 
-    /**
-     * Parses a {@linkplain java.io.Reader} into a {@linkplain retrofit.client.Response} object.
-     *
-     * @param url URL this mock response is answering for
-     * @param input {@link java.io.Reader} to read from
-     * @return {@link retrofit.client.Response} object filled with data from the {@linkplain java.io.Reader}
-     * @throws IOException If an I/O error occurs while parsing
-     */
-    public static Response parse(String url, Reader input) throws IOException {
-        try (BufferedReader reader = new BufferedReader(input)) {
-            return parse(url, reader);
-        }
+    public PlaceholderReplacer withLength(long length) {
+      this.length = String.valueOf(length);
+      return this;
     }
 
-    /**
-     * Parses an {@linkplain java.io.InputStream} into a {@linkplain retrofit.client.Response} object.
-     *
-     * @param url URL this mock response is answering for
-     * @param is {@link java.io.InputStream} to read from
-     * @return {@link retrofit.client.Response} object filled with data from the {@linkplain java.io.InputStream}
-     * @throws IOException If an I/O error occurs while parsing
-     */
-    public static Response parse(String url, InputStream is) throws IOException {
-        try (Reader reader = new InputStreamReader(is)) {
-            return parse(url, reader);
-        }
+    public PlaceholderReplacer withLength(TypedByteArray byteArray) {
+      return withLength(byteArray.length());
     }
 
-    /**
-     * Parses a {@linkplain java.io.File} into a {@linkplain retrofit.client.Response} object.
-     *
-     * @param url URL this mock response is answering for
-     * @param file {@link java.io.File} to read from
-     * @return {@link retrofit.client.Response} object filled with data from the {@linkplain java.io.File}
-     * @throws IOException If an I/O error occurs while parsing
-     */
-    public static Response parse(String url, File file) throws IOException {
-        try (Reader reader = new FileReader(file)) {
-            return parse(url, reader);
-        }
+    public PlaceholderReplacer withLength(TypedInput input) {
+      return withLength((TypedByteArray) input);
     }
 
-    /**
-     * Parses a {@linkplain java.nio.file.Path} into a {@linkplain retrofit.client.Response} object.
-     *
-     * @param url URL this mock response is answering for
-     * @param path {@link java.nio.file.Path} to read from
-     * @return {@link retrofit.client.Response} object filled with data from the {@linkplain java.nio.file.Path}
-     * @throws IOException If an I/O error occurs while parsing
-     */
-    public static Response parse(String url, Path path) throws IOException {
-        return parse(url, path.toFile());
+    public PlaceholderReplacer withDate(Date date) {
+      this.date = dateFormat.format(date);
+      return this;
     }
 
-    private interface Status {
-        int code();
-        String reason();
+    public List<Header> build() {
+      List<Header> result = new ArrayList<>(headers.size());
+      for (Header header : headers) {
+        switch (header.getValue()) {
+          case "${LENGTH}":
+            result.add(new Header(header.getName(), length));
+            break;
+          case "${DATE}":
+            result.add(new Header(header.getName(), date));
+            break;
+          default:
+            result.add(header);
+        }
+      }
+      return result;
     }
 
-    private static Status status(BufferedReader input) throws IOException {
-        String statusLine = input.readLine();
-        if (statusLine == null || statusLine.isEmpty()) {
-            throw invalidStatusLine();
-        }
-        final Matcher matcher = STATUS_LINE_PATTERN.matcher(statusLine);
-        if (matcher.find()) {
-            return new Status() {
-                public int code() { return Integer.parseInt(matcher.group("statusCode")); }
-                public String reason() { return matcher.group("statusReason"); }
-            };
-        } else {
-            throw invalidStatusLine();
-        }
-    }
-
-    private static RuntimeException invalidStatusLine() {
-        throw new IllegalArgumentException("Input does not begin with a status line");
-    }
-
-    private static List<Header> headers(BufferedReader input) throws IOException {
-        List<Header> headers = new ArrayList<>();
-        String line;
-        while (isNotEmptyOrNull(line = input.readLine())) {
-            Matcher m = HEADER_PATTERN.matcher(line);
-            if (m.find()) {
-                headers.add(new Header(m.group("name"), m.group("value")));
-            }
-        }
-        return headers;
-    }
-
-    private static boolean isNotEmptyOrNull(final String line) {
-        return line != null && !line.isEmpty();
-    }
-
-    private static String contentType(List<Header> headers) {
-        String contentType = DEFAULT_CONTENT_TYPE;
-        for (Header header : headers) {
-            if ("Content-Type".equalsIgnoreCase(header.getName())) {
-                contentType = header.getValue();
-                break;
-            }
-        }
-        return contentType;
-    }
-
-    private static TypedInput body(String mimeType, BufferedReader input) throws IOException {
-        StringBuilder body = new StringBuilder();
-        String line;
-        while ((line = input.readLine()) != null) {
-            body.append(line).append('\n');
-        }
-        return new TypedByteArray(mimeType, body.toString().getBytes(charset(mimeType)));
-    }
-
-    private static Charset charset(String mimeType) {
-        Matcher m = CHARSET_PATTERN.matcher(mimeType);
-        if (m.find()) {
-            return Charset.forName(m.group("charset"));
-        } else {
-            return Charset.defaultCharset();
-        }
-    }
-
-    private static class PlaceholderReplacer {
-
-        static final TimeZone GMT = TimeZone.getTimeZone("GMT");
-        final DateFormat dateFormat;
-        final List<Header> headers;
-        String length;
-        String date;
-
-        PlaceholderReplacer(List<Header> headers) {
-            this.headers = headers;
-            this.dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
-            this.dateFormat.setTimeZone(GMT);
-        }
-
-        public PlaceholderReplacer withLength(long length) {
-            this.length = String.valueOf(length);
-            return this;
-        }
-
-        public PlaceholderReplacer withLength(TypedByteArray byteArray) {
-            return withLength(byteArray.length());
-        }
-
-        public PlaceholderReplacer withLength(TypedInput input) {
-            return withLength((TypedByteArray)input);
-        }
-
-        public PlaceholderReplacer withDate(Date date) {
-            this.date = dateFormat.format(date);
-            return this;
-        }
-
-        public List<Header> build() {
-            List<Header> result = new ArrayList<>(headers.size());
-            for (Header header : headers) {
-                switch (header.getValue()) {
-                    case "${LENGTH}" :
-                        result.add(new Header(header.getName(), length));
-                        break;
-                    case "${DATE}" :
-                        result.add(new Header(header.getName(), date));
-                        break;
-                    default:
-                        result.add(header);
-                }
-            }
-            return result;
-        }
-
-    }
+  }
 
 }


### PR DESCRIPTION
I wasn't able to use retromock with my instrumentation test suite, because it wasn't building against the Android SDK.

I've made a few changes to allow that (and messed up your code formating, sorry).

I haven't tried this with my use case scenario, but thought it a good share.

fixes #2 
